### PR TITLE
Add constants modification via NT

### DIFF
--- a/common/src/main/java/us/ilite/common/config/SystemSettings.java
+++ b/common/src/main/java/us/ilite/common/config/SystemSettings.java
@@ -6,14 +6,14 @@ import java.util.concurrent.TimeUnit;
 
 import com.team254.lib.util.ConstantsBase;
 
+import us.ilite.common.lib.util.NetworkTablesConstantsBase;
 import us.ilite.common.types.ETrackingType;
 import us.ilite.common.types.input.ELogitech310;
 
-public class SystemSettings extends ConstantsBase {
+public class SystemSettings extends NetworkTablesConstantsBase {
 
 
     public static double kControlLoopPeriod = 0.01; // seconds
-    public static TimeUnit SYSTEM_TIME_UNIT = TimeUnit.SECONDS;
 
     public static double NETWORK_TABLE_UPDATE_RATE = 0.01;
 
@@ -97,11 +97,6 @@ public class SystemSettings extends ConstantsBase {
     public static double kDriveVelocity_kD = 10.0;
 //    public static double kDriveVelocity_kF = (1023.0 / 1155.0); // We don't care about this feedforward because we inject our own with ArbitraryFeedforward
     public static double kDriveVelocity_kF = 0.0; // We don't care about this feedforward because we inject our own with ArbitraryFeedforward
-    @Override
-    public String getFileLocation() {
-        return "~/constants.txt";
-    }
 
-
-    public static final int ULTRASONIC_PORT = 2;
+    public static int ULTRASONIC_PORT = 2;
 }

--- a/common/src/main/java/us/ilite/common/lib/util/NetworkTablesConstantsBase.java
+++ b/common/src/main/java/us/ilite/common/lib/util/NetworkTablesConstantsBase.java
@@ -47,6 +47,7 @@ public abstract class NetworkTablesConstantsBase {
                     entry.setString(mGson.toJson(f.get(this)));
                 } catch (Exception e) {
                     mLog.error("Failed value write for ", entry.getName());
+                    mLog.exception(e);
                 }
             }
         }
@@ -59,9 +60,8 @@ public abstract class NetworkTablesConstantsBase {
                 try {
                     f.set(this, mGson.fromJson(entry.getString(""), f.getGenericType()));
                 } catch (IllegalArgumentException | IllegalAccessException e) {
-                    // TODO Auto-generated catch block
-                    // e.printStackTrace();
                     mLog.error("Failed value retrieval for ", entry.getName());
+                    mLog.exception(e);
                 }
             }
         } 

--- a/common/src/main/java/us/ilite/common/lib/util/NetworkTablesConstantsBase.java
+++ b/common/src/main/java/us/ilite/common/lib/util/NetworkTablesConstantsBase.java
@@ -9,6 +9,8 @@ package us.ilite.common.lib.util;
 
 import java.lang.reflect.Field;
 
+import com.flybotix.hfr.util.log.ILog;
+import com.flybotix.hfr.util.log.Logger;
 import com.google.gson.Gson;
 
 import edu.wpi.first.networktables.EntryListenerFlags;
@@ -23,6 +25,8 @@ import us.ilite.common.config.SystemSettings;
 public abstract class NetworkTablesConstantsBase {
 
     private static final NetworkTableInstance kNetworkTableInstance = NetworkTableInstance.getDefault();
+
+    private final ILog mLog = Logger.createLog(NetworkTablesConstantsBase.class);
     private final NetworkTable mTable;
     private final Field[] mDeclaredFields;
     private final Gson mGson;
@@ -41,8 +45,8 @@ public abstract class NetworkTablesConstantsBase {
 
                 try {
                     entry.setString(mGson.toJson(f.get(this)));
-                } catch (IllegalArgumentException | IllegalAccessException e) {
-                    System.err.println("Failed value write for " + entry.getName());
+                } catch (Exception e) {
+                    mLog.error("Failed value write for ", entry.getName());
                 }
             }
         }
@@ -57,7 +61,7 @@ public abstract class NetworkTablesConstantsBase {
                 } catch (IllegalArgumentException | IllegalAccessException e) {
                     // TODO Auto-generated catch block
                     // e.printStackTrace();
-                    System.err.println("Failed value retrieval for " + entry.getName());
+                    mLog.error("Failed value retrieval for ", entry.getName());
                 }
             }
         } 

--- a/common/src/main/java/us/ilite/common/lib/util/NetworkTablesConstantsBase.java
+++ b/common/src/main/java/us/ilite/common/lib/util/NetworkTablesConstantsBase.java
@@ -1,0 +1,66 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package us.ilite.common.lib.util;
+
+import java.lang.reflect.Field;
+
+import com.google.gson.Gson;
+
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import us.ilite.common.config.SystemSettings;
+
+/**
+ * Add your docs here.
+ */
+public abstract class NetworkTablesConstantsBase {
+
+    private static final NetworkTableInstance kNetworkTableInstance = NetworkTableInstance.getDefault();
+    private final NetworkTable mTable;
+    private final Field[] mDeclaredFields;
+    private final Gson mGson;
+
+
+    public NetworkTablesConstantsBase() {
+        mTable = kNetworkTableInstance.getTable(this.getClass().getSimpleName().toUpperCase());
+        mDeclaredFields = this.getClass().getDeclaredFields();
+        mGson = new Gson();
+    }
+
+    public void writeToNetworkTables() {
+        for (Field f : mDeclaredFields) {
+            if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) {
+                NetworkTableEntry entry = mTable.getEntry(f.getName());
+
+                try {
+                    entry.setString(mGson.toJson(f.get(this)));
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    System.err.println("Failed value write for " + entry.getName());
+                }
+            }
+        }
+    }
+
+    public void loadFromNetworkTables() {
+        for (Field f : mDeclaredFields) {
+            NetworkTableEntry entry = mTable.getEntry(f.getName());
+            if(entry.exists()) {
+                try {
+                    f.set(this, mGson.fromJson(entry.getString(""), f.getGenericType()));
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    // TODO Auto-generated catch block
+                    // e.printStackTrace();
+                    System.err.println("Failed value retrieval for " + entry.getName());
+                }
+            }
+        } 
+    }
+
+}


### PR DESCRIPTION
This uses some reflection concepts borrowed from `ConstantsBase` to obtain and set field values via reflection. Each field's value is serialized with GSON and sent over NetworkTables, where it is editable by Shuffleboard or any other NT client. Values set on NT can be deserialized and written to SystemSettings at will.