### PR TITLE
Feature/multi application

### DIFF
--- a/display/build.gradle
+++ b/display/build.gradle
@@ -63,13 +63,12 @@ dependencies {
     //evaluated so that the run task, which is created by the application plugin, 
     //has been fully created so that these tasks can inherit the classpath and modules.
     afterEvaluate {project->
-
         javaFxMains.each{key, value ->
             project.task(["type":JavaExec, "description" : value.description,"group" : "application"], 'run'+key) {
                 classpath = sourceSets.main.runtimeClasspath
                 main = value.mainClass
                 List<String> moduleJvmArgs = new ArrayList<String>(Arrays.asList("--module-path",sourceSets.main.runtimeClasspath.getAsPath()));
-                String addModules = String.join(",", javaFxMods);
+                String addModules = String.join(",", project.extensions.javafx.modules);
                 List<String> jvmArgs = new ArrayList<String>();
                 jvmArgs.add("--add-modules");
                 jvmArgs.add(addModules);

--- a/display/build.gradle
+++ b/display/build.gradle
@@ -11,8 +11,10 @@ apply plugin: 'org.openjfx.javafxplugin'
 
 apply from: 'plot.gradle'
 
+def javaFxMods = [ 'javafx.base', 'javafx.controls', 'javafx.media', 'javafx.graphics', 'javafx.fxml' ]
+
 javafx {
-    modules = [ 'javafx.base', 'javafx.controls', 'javafx.media', 'javafx.graphics', 'javafx.fxml' ]
+    modules = javaFxMods
     version = "11.0.+"
 }
 
@@ -38,5 +40,35 @@ dependencies {
     runtime group: "edu.wpi.first.ntcore", name: "ntcore-jni", version: "2019.+", classifier: "all"
     compile group: "edu.wpi.first.ntcore", name: "ntcore-java", version: "2019.+"
     compile group: "edu.wpi.first.wpiutil", name: "wpiutil-java", version: "2019.+"
+    
+    project.
+    // task runApp(type: JavaExec) {
+    //     classpath = sourceSets.main.runtimeClasspath
+    //     main = 'us.ilite.display.Main'
 
+    //     List<String> moduleJvmArgs = new ArrayList<String>(Arrays.asList("--module-path",sourceSets.main.runtimeClasspath.getAsPath()));
+        
+    //     String addModules = String.join(",", javaFxMods);
+
+    //     List<String> jvmArgs = new ArrayList<String>();
+    //     jvmArgs.add("--add-modules");
+    //     jvmArgs.add(addModules);
+    //     jvmArgs.addAll(moduleJvmArgs);
+    //     setJvmArgs(jvmArgs);
+        
+    // }
+
+    afterEvaluate {project->
+        project.task(["type":JavaExec], 'runApp') {
+            classpath = sourceSets.main.runtimeClasspath
+            main = 'us.ilite.display.Main'
+            List<String> moduleJvmArgs = new ArrayList<String>(Arrays.asList("--module-path",sourceSets.main.runtimeClasspath.getAsPath()));
+            String addModules = String.join(",", javaFxMods);
+            List<String> jvmArgs = new ArrayList<String>();
+            jvmArgs.add("--add-modules");
+            jvmArgs.add(addModules);
+            jvmArgs.addAll(moduleJvmArgs);
+            setJvmArgs(jvmArgs);
+        }
+    }
 }

--- a/display/build.gradle
+++ b/display/build.gradle
@@ -2,45 +2,11 @@ version '1.0-SNAPSHOT'
 
 apply plugin: 'application'
 apply plugin: 'org.openjfx.javafxplugin'
-//mainClassName = 'eu.hansolo.tilesfxdemo.Main'
-//mainClassName = 'eu.hansolo.tilesfxdemo.MiscDemo'
- mainClassName = 'us.ilite.display.DriverStation'
-// mainClassName = 'us.ilite.display.Main'
-//mainClassName = 'us.ilite.display.testing.AutonConfigDisplay'
-//mainClassName = 'us.ilite.display.testing.TestingDisplay'
-
-def javaFxMains = [
-    'tilesfxdemoMain':
-        ['mainClass'   : 'eu.hansolo.tilesfxdemo.Main',
-         'description' :'Executes the tile demo main'],
-    'tilesfxdemoMiscDemo' : 
-        ['mainClass'   : 'eu.hansolo.tilesfxdemo.MiscDemo',
-         'description' :' Executes the tiles misc demo'
-        ],
-    'driverStation' : 
-        ['mainClass'   : 'us.ilite.display.DriverStation',
-         'description' : 'The main drivers station display'
-        ],
-    'iliteMain' : 
-        ['mainClass'   : 'us.ilite.display.Main',
-         'description' : 'The main display'
-        ],
-    'testinAutonConfig' :
-        ['mainClass'   : 'us.ilite.display.testing.AutonConfigDisplay',
-         'description' : 'The autonomous config display'
-        ],
-    'testDisplay' : 
-        ['mainClass'   : 'us.ilite.display.testing.TestingDisplay',
-         'display'     : 'The testing display'
-        ]
-]
-
+mainClassName = 'us.ilite.display.DriverStation'
 apply from: 'plot.gradle'
 
-def javaFxMods = [ 'javafx.base', 'javafx.controls', 'javafx.media', 'javafx.graphics', 'javafx.fxml' ]
-
 javafx {
-    modules = javaFxMods
+    modules = [ 'javafx.base', 'javafx.controls', 'javafx.media', 'javafx.graphics', 'javafx.fxml' ]
     version = "11.0.+"
 }
 
@@ -66,29 +32,39 @@ dependencies {
     runtime group: "edu.wpi.first.ntcore", name: "ntcore-jni", version: "2019.+", classifier: "all"
     compile group: "edu.wpi.first.ntcore", name: "ntcore-java", version: "2019.+"
     compile group: "edu.wpi.first.wpiutil", name: "wpiutil-java", version: "2019.+"
-    
-    project.
-    // task runApp(type: JavaExec) {
-    //     classpath = sourceSets.main.runtimeClasspath
-    //     main = 'us.ilite.display.Main'
 
-    //     List<String> moduleJvmArgs = new ArrayList<String>(Arrays.asList("--module-path",sourceSets.main.runtimeClasspath.getAsPath()));
-        
-    //     String addModules = String.join(",", javaFxMods);
+    def javaFxMains = [
+    'tilesfxdemoMain':
+        ['mainClass'   : 'eu.hansolo.tilesfxdemo.Main',
+         'description' :'Executes the tile demo main'],
+    'tilesfxdemoMiscDemo' : 
+        ['mainClass'   : 'eu.hansolo.tilesfxdemo.MiscDemo',
+         'description' :' Executes the tiles misc demo'
+        ],
+    'driverStation' : 
+        ['mainClass'   : 'us.ilite.display.DriverStation',
+         'description' : 'The main drivers station display'
+        ],
+    'iliteMain' : 
+        ['mainClass'   : 'us.ilite.display.Main',
+         'description' : 'The main display'
+        ],
+    'testinAutonConfig' :
+        ['mainClass'   : 'us.ilite.display.testing.AutonConfigDisplay',
+         'description' : 'The autonomous config display'
+        ],
+    'testDisplay' : 
+        ['mainClass'   : 'us.ilite.display.testing.TestingDisplay',
+         'display'     : 'The testing display'
+        ]
+]
 
-    //     List<String> jvmArgs = new ArrayList<String>();
-    //     jvmArgs.add("--add-modules");
-    //     jvmArgs.add(addModules);
-    //     jvmArgs.addAll(moduleJvmArgs);
-    //     setJvmArgs(jvmArgs);
-        
-    // }
-
+    //These tasks must be generated after the project has been 
+    //evaluated so that the run task, which is created by the application plugin, 
+    //has been fully created so that these tasks can inherit the classpath and modules.
     afterEvaluate {project->
 
         javaFxMains.each{key, value ->
-            def taskName = "run${key}"
-            println taskName
             project.task(["type":JavaExec, "description" : value.description,"group" : "application"], 'run'+key) {
                 classpath = sourceSets.main.runtimeClasspath
                 main = value.mainClass

--- a/display/build.gradle
+++ b/display/build.gradle
@@ -9,6 +9,32 @@ apply plugin: 'org.openjfx.javafxplugin'
 //mainClassName = 'us.ilite.display.testing.AutonConfigDisplay'
 //mainClassName = 'us.ilite.display.testing.TestingDisplay'
 
+def javaFxMains = [
+    'tilesfxdemoMain':
+        ['mainClass'   : 'eu.hansolo.tilesfxdemo.Main',
+         'description' :'Executes the tile demo main'],
+    'tilesfxdemoMiscDemo' : 
+        ['mainClass'   : 'eu.hansolo.tilesfxdemo.MiscDemo',
+         'description' :' Executes the tiles misc demo'
+        ],
+    'driverStation' : 
+        ['mainClass'   : 'us.ilite.display.DriverStation',
+         'description' : 'The main drivers station display'
+        ],
+    'iliteMain' : 
+        ['mainClass'   : 'us.ilite.display.Main',
+         'description' : 'The main display'
+        ],
+    'testinAutonConfig' :
+        ['mainClass'   : 'us.ilite.display.testing.AutonConfigDisplay',
+         'description' : 'The autonomous config display'
+        ],
+    'testDisplay' : 
+        ['mainClass'   : 'us.ilite.display.testing.TestingDisplay',
+         'display'     : 'The testing display'
+        ]
+]
+
 apply from: 'plot.gradle'
 
 def javaFxMods = [ 'javafx.base', 'javafx.controls', 'javafx.media', 'javafx.graphics', 'javafx.fxml' ]
@@ -59,16 +85,21 @@ dependencies {
     // }
 
     afterEvaluate {project->
-        project.task(["type":JavaExec], 'runApp') {
-            classpath = sourceSets.main.runtimeClasspath
-            main = 'us.ilite.display.Main'
-            List<String> moduleJvmArgs = new ArrayList<String>(Arrays.asList("--module-path",sourceSets.main.runtimeClasspath.getAsPath()));
-            String addModules = String.join(",", javaFxMods);
-            List<String> jvmArgs = new ArrayList<String>();
-            jvmArgs.add("--add-modules");
-            jvmArgs.add(addModules);
-            jvmArgs.addAll(moduleJvmArgs);
-            setJvmArgs(jvmArgs);
+
+        javaFxMains.each{key, value ->
+            def taskName = "run${key}"
+            println taskName
+            project.task(["type":JavaExec, "description" : value.description,"group" : "application"], 'run'+key) {
+                classpath = sourceSets.main.runtimeClasspath
+                main = value.mainClass
+                List<String> moduleJvmArgs = new ArrayList<String>(Arrays.asList("--module-path",sourceSets.main.runtimeClasspath.getAsPath()));
+                String addModules = String.join(",", javaFxMods);
+                List<String> jvmArgs = new ArrayList<String>();
+                jvmArgs.add("--add-modules");
+                jvmArgs.add(addModules);
+                jvmArgs.addAll(moduleJvmArgs);
+                setJvmArgs(jvmArgs);
+            }
         }
     }
 }


### PR DESCRIPTION
This commit updates the build.gradle in the display project so that all of the JavaFx main classes can be executed from the command line. Previously there was a single run command that's added by the application plugin, This run task can only execute the value in the mainClassName. There's no way to dynamically change the value of mainClassName. 

This solution will generate a task for each of the applications. The tasks take the format: 
run<task name>. The tasks and their main methods are defined in the map: javaFxMains 

Here are the tasks that can be run:

- runtilesfxdemoMain: eu.hansolo.tilesfxdemo.Main

- runtilesfxdemoMiscDemo: eu.hansolo.tilesfxdemo.MiscDemo

- rundriverStation: us.ilite.display.DriverStation

- runiliteMain: us.ilite.display.Main

- runtestinAutonConfig: us.ilite.display.testing.AutonConfigDisplay

- runtestDisplay: us.ilite.display.testing.TestingDisplay